### PR TITLE
Service mode

### DIFF
--- a/include/mm2/rx/crtp_base.hpp
+++ b/include/mm2/rx/crtp_base.hpp
@@ -128,7 +128,7 @@ struct CrtpBase {
 
   /// Encoding of commands bit by bit
   ///
-  /// \param  time  Last pulse on tracks in us
+  /// \param  time  Time in µs
   void receive(uint32_t time) {
     auto const bit{time2bit(time)};
     if (bit == Invalid) return reset();

--- a/include/mm2/timing.hpp
+++ b/include/mm2/timing.hpp
@@ -23,9 +23,9 @@ enum Timing {
   Bit0Max = Bit0Norm + 6u,   ///< Maximal timing for a 0-bit
 };
 
-/// Convert timing to bit
+/// Convert time to bit
 ///
-/// \param  time  Last pulse on tracks in us
+/// \param  time  Time in µs
 /// \return Bit
 constexpr Bit time2bit(uint32_t time) {
   if (time >= Bit1Min && time <= Bit1Max) return _1;


### PR DESCRIPTION
Adds a getter to query whether a decoder is in service mode. This feature is used in ZIMO decoders to check during a lengthy boot process whether further commands should be waited for.